### PR TITLE
add taiyi framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vscode/*
+.git/*
+
+setting.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+CXX := g++
+
+CXXFLAGS := -std=c++11 -Wall
+
+INCLUDE_COMMON = src/common
+INCLUDE = -I$(INCLUDE_COMMON)
+
+LIBDIR := /usr/local/bin
+LDFLAGS := -L$(LIBDIR) -pthread
+
+TARGET := test
+
+SRCS := $(wildcard src/*.cc src/common/*.cc src/store/*.cc src/md/*.cc src/trade/*.cc)
+
+OBJS := $(SRCS:.cc=.o)
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(CXX) $(LDFLAGS) $^ -o $@
+
+%.o: %.cc
+	$(CXX) $(CXXFLAGS) -c $< -o $@ $(INCLUDE)
+
+clean:
+	rm -f $(OBJS) $(TARGET)

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -1,0 +1,37 @@
+/*
+ * common.h
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+#include <cassert>
+
+#define DBG_ASSERT(expr) assert(expr)
+
+#define MAX_DATA_BUF_NUM (5)
+
+#define TAIYI_STORE_CONTAINER_ID (1)
+#define TAIYI_MD_CONTAINER_ID ((TAIYI_STORE_CONTAINER_ID)+1)
+#define TAIYI_MAX_MD_CONTAINER_NUM (8)
+#define TAIYI_TRADE_CONTAINER_ID ((TAIYI_MD_CONTAINER_ID)+(TAIYI_MAX_MD_CONTAINER_NUM))
+
+#define TAIYI_STORE_MODULE_ID (1)
+#define TAIYI_MD_MODULE_ID ((TAIYI_STORE_MODULE_ID)+1)
+#define TAIYI_MAX_MD_MODULE_NUM (4096)
+#define TAIYI_TRADE_MODULE_ID ((TAIYI_MD_MODULE_ID)+(TAIYI_MAX_MD_MODULE_NUM))
+#define TAIYI_MAX_TRADE_MODULE_NUM (TAIYI_MAX_MD_MODULE_NUM)
+
+
+typedef uint32_t CmdCode;
+
+typedef int Status;
+#define StatusOK (0)
+#define StatusError (-1)
+#define StatusNotFound (1)
+#define StatusNoMemory (2)

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -1,0 +1,28 @@
+/*
+ * config.h
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <vector>
+#include <string>
+
+struct InstrumentConfig {
+    std::string instrumentId;
+};
+
+struct Config {
+    uint32_t mdContainerNum;
+    uint32_t tradeContainerNum;
+
+    std::vector<InstrumentConfig*> instruments;
+
+    bool mockCTPApi;
+};

--- a/src/common/container.cc
+++ b/src/common/container.cc
@@ -1,0 +1,70 @@
+/*
+ * container.cc
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#include "container.h"
+#include "module.h"
+
+#include "log.h"
+#include "mem.h"
+
+Container::Container(uint32_t containerId, const std::string& containerName, bool isPolling) {
+    _containerId = containerId;
+    _containerName = containerName;
+    _isPolling = isPolling;
+}
+
+Status Container::RegisterModule(Module* pModule) {
+    LOG_INFO("RegisterModule containerId %d containerName %s moduleId %d",
+        _containerId, _containerName.c_str(), pModule->GetModuleId());
+
+    std::pair<std::map<uint32_t, Module*>::iterator, bool> ret;
+    ret = _modules.insert(std::pair<uint32_t, Module*>(pModule->GetModuleId(), pModule));
+    if (!ret.second) {
+        LOG_ERROR("RegisterModule failed, containerId %d containerName %s moduleId %d",
+            _containerId, _containerName.c_str(), pModule->GetModuleId());
+        return StatusError;
+    }
+    return StatusOK;
+}
+
+Module* Container::GetModule(uint32_t moduleId) {
+    std::map<uint32_t, Module*>::iterator iter;
+    iter = _modules.find(moduleId);
+    if (iter == _modules.end()) {
+        LOG_ERROR("GetModule failed, containerId %d containerName %s moduleId %d",
+            _containerId, _containerName.c_str(), moduleId);
+        return NULL;
+    }
+    return iter->second;
+}
+
+Status Container::Start() {
+    LOG_INFO("StartContainer Id %d Name %s Polling %d", _containerId, _containerName.c_str(), _isPolling);
+    if (_isPolling) {
+        _thread = std::thread([this] { this->Polling(); }); // 单独启动轮询线程
+    } else {
+        // TODO 不启动轮询线程
+    }
+    return StatusOK;
+}
+
+void Container::Polling() {
+    while (true) {
+        Message* msg = NULL;
+        if (_lfmQueue.Pop(&msg)) {
+            Module* pModule = GetModule(msg->dstModuleId);
+            if (!pModule) {
+                LOG_ERROR("Recieve invalid msg, cmd %d, srcContainerId %d srcModuleId %d dstContainerId %d dstModuleId %d",
+                    msg->cmd, msg->srcContainerId, msg->srcModuleId, msg->dstContainerId, msg->dstModuleId);
+                continue;
+            }
+            pModule->Dispatch(msg);
+        }
+        std::this_thread::yield();
+    }
+}

--- a/src/common/container.h
+++ b/src/common/container.h
@@ -1,0 +1,55 @@
+/*
+ * container.h
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <map>
+#include <string>
+#include <thread>
+
+#include "common.h"
+#include "lock_free_queue.h"
+#include "message.h"
+
+class Module;
+
+class Container {
+  public:
+    Container(uint32_t containerId, const std::string& containerName, bool isPolling);
+    virtual ~Container() {} // TODO free
+
+    uint32_t GetContainerId() { return _containerId; }
+    std::string GetContainerName() { return _containerName; }
+
+    Status RegisterModule(Module* pModule);
+    Module* GetModule(uint32_t moduleId);
+
+  public:
+    Status Start();
+    void Stop() {} // TODO
+    void Polling();
+
+    bool Push(Message *msg) { return _lfmQueue.Push(msg); }
+
+  private:
+    std::map<uint32_t, Module*> _modules;
+
+  private:
+    LockFreeMessageQueue _lfmQueue;
+
+  private:
+    uint32_t _containerId;
+    std::string _containerName;
+
+  private:
+    bool _isPolling;
+    std::thread _thread;
+};

--- a/src/common/lock_free_queue.h
+++ b/src/common/lock_free_queue.h
@@ -1,0 +1,57 @@
+/*
+ * lock_free_queue.h
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <vector>
+#include <atomic>
+
+#include "message.h"
+
+#define MAX_WAITING_MESSAGE_NUM (10000) // 队列中消息数量，如果消息入队失败，说明dst处理比较慢，src需要重试
+
+class LockFreeMessageQueue {
+  public:
+    LockFreeMessageQueue() : _queue(MAX_WAITING_MESSAGE_NUM), _readIndex(0), _writeIndex(0) {}
+    virtual ~LockFreeMessageQueue() {}
+
+    bool Push(Message* pMsg) {
+        size_t currentWriteIndex = _writeIndex.load(std::memory_order_relaxed);
+        size_t nextWriteIndex = (currentWriteIndex + 1) % _queue.size();
+
+        if (nextWriteIndex == _readIndex.load(std::memory_order_acquire)) {
+            return false; // 队列已满
+        }
+
+        _queue[currentWriteIndex] = pMsg;
+        _writeIndex.store(nextWriteIndex, std::memory_order_release);
+
+        return true;
+    }
+
+    bool Pop(Message **ppMsg) {
+        size_t currentReadIndex = _readIndex.load(std::memory_order_relaxed);
+
+        if (currentReadIndex == _writeIndex.load(std::memory_order_acquire)) {
+            return false; // 队列为空
+        }
+
+        *ppMsg = _queue[currentReadIndex];
+        _readIndex.store((currentReadIndex+1)%_queue.size(), std::memory_order_release);
+
+        return true;
+    }
+
+  private:
+    std::vector<Message*> _queue;
+    std::atomic<size_t> _readIndex;
+    std::atomic<size_t> _writeIndex;
+};

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -1,0 +1,30 @@
+/*
+ * log.h
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#pragma once
+
+#include <cstdio>
+//#include
+
+#define LOG_DEBUG(...) \
+    do { \
+        printf(__VA_ARGS__); \
+        printf("\n"); \
+    } while(0)
+
+#define LOG_INFO(...) \
+    do { \
+        printf(__VA_ARGS__); \
+        printf("\n"); \
+    } while(0)
+
+#define LOG_ERROR(...) \
+    do { \
+        printf(__VA_ARGS__); \
+        printf("\n"); \
+    } while(0)

--- a/src/common/mem.h
+++ b/src/common/mem.h
@@ -1,0 +1,12 @@
+/*
+ * mem.h
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#pragma once
+
+#define TAIYI_MALLOC malloc
+#define TAIYI_FREE free

--- a/src/common/message.h
+++ b/src/common/message.h
@@ -1,0 +1,24 @@
+/*
+ * message.h
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#include "common.h"
+
+struct Message {
+    uint32_t srcContainerId;
+    uint32_t srcModuleId;
+    uint32_t dstContainerId;
+    uint32_t dstModuleId;
+
+    CmdCode cmd;
+    void* data[MAX_DATA_BUF_NUM];
+};

--- a/src/common/module.cc
+++ b/src/common/module.cc
@@ -1,0 +1,21 @@
+/*
+ * module.cc
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#include "module.h"
+#include "log.h"
+#include "mem.h"
+#include "container.h"
+#include "proc.h"
+
+Status Module::SendMsg(Message* msg) {
+    Container* dstContainer = TaiyiMain()->GetContainer(msg->dstContainerId);
+    if (dstContainer->Push(msg)) {
+        return StatusOK;
+    }
+    return StatusError; // TODO 队列满，异常处理
+}

--- a/src/common/module.h
+++ b/src/common/module.h
@@ -1,0 +1,31 @@
+/*
+ * module.h
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#include "message.h"
+#include "container.h"
+
+class Module {
+  public:
+    Module(uint32_t moduleId, Container* pContainer) : _moduleId(moduleId), _container(pContainer) {}
+    virtual ~Module() {} // TODO
+
+    uint32_t GetModuleId() { return _moduleId; }
+
+  public:
+    virtual Status Dispatch(Message* msg) = 0;
+    Status SendMsg(Message* msg);
+
+  private:
+    uint32_t _moduleId;
+    Container* _container;
+};

--- a/src/common/proc.cc
+++ b/src/common/proc.cc
@@ -1,0 +1,72 @@
+/*
+ * proc.cc
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#include "proc.h"
+
+#include "log.h"
+#include "mem.h"
+
+Proc Proc::_procInstance;
+
+Status Proc::RegisterContainer(Container* pContainer) {
+    LOG_INFO("RegisterContainer id %d name: %s",
+        pContainer->GetContainerId(), pContainer->GetContainerName().c_str());
+
+    std::pair<std::map<uint32_t, Container*>::iterator, bool> ret;
+    ret = _containers.insert(std::pair<uint32_t, Container*>(pContainer->GetContainerId(), pContainer));
+    if (!ret.second) {
+        LOG_ERROR("RegisterContainer failed, id %d name: %s",
+            pContainer->GetContainerId(), pContainer->GetContainerName().c_str());
+        return StatusError;
+    }
+    return StatusOK;
+}
+
+Container* Proc::GetContainer(uint32_t containerId) {
+    std::map<uint32_t, Container*>::iterator iter;
+    iter = _containers.find(containerId);
+    if (iter == _containers.end()) {
+        LOG_ERROR("GetContainer failed, containerId %d", containerId);
+        return NULL;
+    }
+    return iter->second;
+}
+
+Status Proc::RegisterInstrumentLocation(InstrumentLocation& location) {
+    LOG_INFO("RegisterInstrumentLocation InstrumentId: %s mdContainerId %d mdModuleId %d tradeContainerId %d tradeModuleId %d",
+        location.instrumentId.c_str(), location.mdContainerId, location.mdModuleId, location.tradeContainerId, location.tradeModuleId);
+
+    InstrumentLocation *iLoc = (InstrumentLocation*)TAIYI_MALLOC(sizeof(InstrumentLocation));
+    if (!iLoc) {
+        LOG_ERROR("Alloc InstrumentLocation Memory failed");
+        return StatusNoMemory;
+    }
+    iLoc->instrumentId = location.instrumentId;
+    iLoc->mdContainerId = location.mdContainerId;
+    iLoc->mdModuleId = location.mdModuleId;
+    iLoc->tradeContainerId = location.tradeContainerId;
+    iLoc->tradeModuleId = location.tradeModuleId;
+
+    std::pair<std::map<std::string, InstrumentLocation*>::iterator, bool> ret;
+    ret = _locations.insert(std::pair<std::string, InstrumentLocation*>(iLoc->instrumentId, iLoc));
+    if (!ret.second) {
+        LOG_ERROR("Insert instrument location failed, id %s", iLoc->instrumentId.c_str());
+        return StatusError;
+    }
+    return StatusOK;
+}
+
+InstrumentLocation* Proc::GetInstrumentLocation(const std::string& instrumentId) {
+    std::map<std::string, InstrumentLocation*>::iterator iter;
+    iter = _locations.find(instrumentId);
+    if (iter == _locations.end()) {
+        LOG_ERROR("GetInstrumentLocation NOT FOUND, instrumentId %s", instrumentId.c_str());
+        return NULL;
+    }
+    return iter->second;
+}

--- a/src/common/proc.h
+++ b/src/common/proc.h
@@ -1,0 +1,51 @@
+/*
+ * proc.h
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <map>
+#include <string>
+
+#include "container.h"
+#include "common.h"
+
+#define TaiyiMain() Proc::GetProcInstance()
+
+struct InstrumentLocation {
+    std::string instrumentId;
+    uint32_t mdContainerId;
+    uint32_t mdModuleId;
+    uint32_t tradeContainerId;
+    uint32_t tradeModuleId;
+};
+
+class Proc {
+  public:
+    static Proc *GetProcInstance() { return &_procInstance; }
+
+  public:
+    Status RegisterContainer(Container* container);
+    Container* GetContainer(uint32_t containerId);
+
+    Status RegisterInstrumentLocation(InstrumentLocation& location);
+    InstrumentLocation* GetInstrumentLocation(const std::string& instrumentId);
+
+  private:
+    Proc() {}
+    virtual ~Proc() {} // TODO free
+
+  private:
+    std::map<uint32_t, Container*> _containers;
+    std::map<std::string, InstrumentLocation*> _locations;
+
+  private:
+    static Proc _procInstance;
+};

--- a/src/common/protocol.h
+++ b/src/common/protocol.h
@@ -1,0 +1,16 @@
+/*
+ * protocol.h
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+
+enum TaiyiCmdCode {
+    PushMarketDataReq = 1
+};

--- a/src/md/market_data.cc
+++ b/src/md/market_data.cc
@@ -1,0 +1,31 @@
+/*
+ * market_data.cc
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#include "market_data.h"
+
+#include "log.h"
+#include "protocol.h"
+
+Status MarketDataModule::Dispatch(Message* msg) {
+    switch (msg->cmd) {
+        case PushMarketDataReq:
+            return HandlePushMarketDataReq(msg);
+    }
+    return StatusOK;
+}
+
+
+
+
+Status MarketDataModule::HandlePushMarketDataReq(Message* msg) {
+    LOG_DEBUG("HandlePushMarketData");
+
+    // TODO
+
+    return StatusOK;
+}

--- a/src/md/market_data.h
+++ b/src/md/market_data.h
@@ -1,0 +1,32 @@
+/*
+ * market_data.h
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <string>
+
+#include "module.h"
+
+class MarketDataModule : public Module {
+  public:
+    MarketDataModule(uint32_t moduleId, Container* pContainer) : Module(moduleId, pContainer) {} // TODO
+    ~MarketDataModule() {} // TODO
+
+  public:
+    Status Dispatch(Message* msg);
+
+  private:
+    Status HandlePushMarketDataReq(Message* msg);
+
+  private:
+    std::string _instrumentId;
+    // TODO 行情记录
+};

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -1,0 +1,28 @@
+/*
+ * store.h
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <string>
+
+#include "module.h"
+
+class StoreModule : public Module {
+  public:
+    StoreModule(uint32_t moduleId, Container* pContainer) : Module(moduleId, pContainer) {} // TODO
+    ~StoreModule() {} // TODO
+
+  public:
+    Status Dispatch(Message* msg) { return StatusError; } // TODO
+
+  private:
+    std::string _filePath; // TODO
+};

--- a/src/taiyi_main.cc
+++ b/src/taiyi_main.cc
@@ -1,0 +1,130 @@
+/*
+ * taiyi_main.cc
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#include "common/proc.h"
+#include "common/config.h"
+#include "common/mem.h"
+
+#include "store/store.h"
+#include "md/market_data.h"
+#include "trade/trade.h"
+
+Container* NewContainer(uint32_t containerId, std::string& containerName, bool isPolling) {
+    Container* c = new Container(containerId, containerName, isPolling);
+    return c;
+}
+
+void RegisterContainer(Config* cfg) {
+    std::string storeContainerName = "store";
+    Container* storeContainer = NewContainer(TAIYI_STORE_CONTAINER_ID, storeContainerName, true);
+    Status ret = TaiyiMain()->RegisterContainer(storeContainer);
+    DBG_ASSERT(ret == StatusOK);
+    Module* storeModule = new StoreModule(TAIYI_STORE_MODULE_ID, storeContainer);
+    ret = storeContainer->RegisterModule(storeModule);
+    DBG_ASSERT(ret == StatusOK);
+
+    std::vector<Container*> mdContainers(cfg->mdContainerNum);
+    for (uint32_t i = 0; i < cfg->mdContainerNum; i++) {
+        std::string name = "md_" + std::to_string(i);
+        mdContainers[i] = NewContainer(TAIYI_MD_CONTAINER_ID+i, name, true);
+        Status ret = TaiyiMain()->RegisterContainer(mdContainers[i]);
+        DBG_ASSERT(ret == StatusOK);
+    }
+    std::vector<Container*> tradeContainers(cfg->tradeContainerNum);
+    for (uint32_t i = 0; i < cfg->tradeContainerNum; i++) {
+        std::string name = "trade_" + std::to_string(i);
+        tradeContainers[i] = NewContainer(TAIYI_TRADE_CONTAINER_ID+i, name, true);
+        Status ret = TaiyiMain()->RegisterContainer(tradeContainers[i]);
+        DBG_ASSERT(ret == StatusOK);
+    }
+
+    for (uint32_t i = 0; i < cfg->instruments.size(); i++) {
+        Container* mdContainer = mdContainers[i%mdContainers.size()];
+        Container* tradeContainer = tradeContainers[i%tradeContainers.size()];
+
+        Module* mdModule = new MarketDataModule(TAIYI_MD_MODULE_ID+i, mdContainer);
+        ret = mdContainer->RegisterModule(mdModule);
+        DBG_ASSERT(ret == StatusOK);
+        Module* tradeModule = new TradeModule(TAIYI_TRADE_MODULE_ID+i, tradeContainer);
+        ret = tradeContainer->RegisterModule(tradeModule);
+        DBG_ASSERT(ret == StatusOK);
+
+        InstrumentLocation location;
+        location.instrumentId = cfg->instruments[i]->instrumentId;
+        location.mdContainerId = mdContainer->GetContainerId();
+        location.mdModuleId = mdModule->GetModuleId();
+        location.tradeContainerId = tradeContainer->GetContainerId();
+        location.tradeModuleId = tradeModule->GetModuleId();
+        ret = TaiyiMain()->RegisterInstrumentLocation(location);
+        DBG_ASSERT(ret == StatusOK);
+    }
+}
+
+void StartContainer(Config* cfg) {
+    Container* storeContainer = TaiyiMain()->GetContainer(TAIYI_STORE_CONTAINER_ID);
+    Status ret = storeContainer->Start();
+    DBG_ASSERT(ret == StatusOK);
+
+    for (uint32_t i = 0; i < cfg->mdContainerNum; i++) {
+        Container* mdContainer = TaiyiMain()->GetContainer(TAIYI_MD_CONTAINER_ID+i);
+        ret = mdContainer->Start();
+        DBG_ASSERT(ret == StatusOK);
+    }
+
+    for (uint32_t i = 0; i < cfg->tradeContainerNum; i++) {
+        Container* tradeContainer = TaiyiMain()->GetContainer(TAIYI_TRADE_CONTAINER_ID+i);
+        ret = tradeContainer->Start();
+        DBG_ASSERT(ret == StatusOK);
+    }
+}
+
+Status StartupContainer(Config* cfg) {
+    RegisterContainer(cfg);
+    StartContainer(cfg);
+    return StatusOK;
+}
+
+Status StartCTPApiService() {
+    // TODO
+    return StatusError;
+}
+
+Status StartMockCTPApiService() {
+    // TODO
+    return StatusOK;
+}
+
+int main(int argc, char *argv[]) {
+    Config* cfg = (Config*)TAIYI_MALLOC(sizeof(Config));
+    DBG_ASSERT(cfg);
+
+    // TODO 读取配置文件
+    cfg->mdContainerNum = 1;
+    cfg->tradeContainerNum = 1;
+    cfg->mockCTPApi = true;
+
+
+    // 解析instrument配置
+
+    Status ret = StartupContainer(cfg);
+    DBG_ASSERT(ret == StatusOK);
+
+
+    if (!cfg->mockCTPApi) {
+        // TODO 启动api/spi服务
+        ret = StartCTPApiService();
+        DBG_ASSERT(ret == StatusOK);
+    } else {
+        ret = StartMockCTPApiService();
+        DBG_ASSERT(ret == StatusOK);
+    }
+
+    // TODO 退出函数
+
+    return 0;
+}

--- a/src/trade/trade.cc
+++ b/src/trade/trade.cc
@@ -1,0 +1,15 @@
+/*
+ * trade.cc
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#include "trade.h"
+
+#include "log.h"
+
+Status TradeModule::Dispatch(Message* msg) {
+    return StatusOK;
+}

--- a/src/trade/trade.h
+++ b/src/trade/trade.h
@@ -1,0 +1,29 @@
+/*
+ * trade.h
+ *
+ * Created on: 20220608
+ *      Author fupeng
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <string>
+
+#include "module.h"
+
+class TradeModule : public Module {
+  public:
+    TradeModule(uint32_t moduleId, Container* pContainer) : Module(moduleId, pContainer) {} // TODO
+    ~TradeModule() {} // TODO
+
+  public:
+    Status Dispatch(Message* msg);
+
+  private:
+    std::string _instrumentId;
+    // TODO 行情记录
+};


### PR DESCRIPTION
Proc：基础框架，管理各个容器Container，内存池等公共模块，负责Container的注册和查找等；使用TaiyiMain函数可以获取到Proc句柄，进而可以注册或查找各Container

Container：每个Container类似一个容器，通常是1个线程进行调度，容器内多个高度内聚的业务按不同的子模块进行管理；同一个Container内使用API通信，不同Container之间使用消息进行通信；比如我们有storeContainer负责行情、交易等信息的持久化，instrumentMdContainer负责行情的处理，可以起多个Container，每个Container负责一部分instrument；instrumentTradeContainer负责报单处理

Module：具体的子模块业务，各个Module子模块高内聚实现自己相关的业务逻辑；比如storeModule专门负责持久化业务，instrumentMdModule负责一个instrument的行情处理，可以将一批instrumentMdModule注册到某个instrumentMdContainer上进行调度；类似的，instrumentTradeModule负责一个instrument的报单处理逻辑

